### PR TITLE
send custom prompts with system role

### DIFF
--- a/src/components/Prompts.tsx
+++ b/src/components/Prompts.tsx
@@ -91,45 +91,10 @@ export function Prompts({
                     description: "New Chat",
                     totalTokens: 0,
                     createdAt: new Date(),
-                  });
-                  await db.messages.add({
-                    id: nanoid(),
-                    chatId: id,
-                    content: prompt.content,
-                    role: "user",
-                    createdAt: new Date(),
+                    promptId: prompt.id,
                   });
                   navigate({ to: `/chats/${id}` });
                   onPlay();
-
-                  const result = await createChatCompletion(apiKey, [
-                    {
-                      role: "system",
-                      content:
-                        "You are ChatGPT, a large language model trained by OpenAI.",
-                    },
-                    { role: "user", content: prompt.content },
-                  ]);
-
-                  const resultDescription =
-                    result.data.choices[0].message?.content;
-                  await db.messages.add({
-                    id: nanoid(),
-                    chatId: id,
-                    content: resultDescription ?? "unknown reponse",
-                    role: "assistant",
-                    createdAt: new Date(),
-                  });
-
-                  if (result.data.usage) {
-                    await db.chats.where({ id: id }).modify((chat) => {
-                      if (chat.totalTokens) {
-                        chat.totalTokens += result.data.usage!.total_tokens;
-                      } else {
-                        chat.totalTokens = result.data.usage!.total_tokens;
-                      }
-                    });
-                  }
                 }}
               >
                 <IconPlayerPlay size={20} />

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,6 +6,7 @@ export interface Chat {
   description: string;
   totalTokens: number;
   createdAt: Date;
+  promptId?: string;
 }
 
 export interface Message {

--- a/src/routes/ChatRoute.tsx
+++ b/src/routes/ChatRoute.tsx
@@ -45,12 +45,18 @@ export function ChatRoute() {
     return db.chats.get(chatId);
   }, [chatId]);
 
+  const userPrompt = useLiveQuery(async () => {
+    if (!chat?.promptId) return null;
+    return db.prompts.get(chat.promptId);
+  }, [chat]);
+
   const [writingCharacter, setWritingCharacter] = useState<string | null>(null);
   const [writingTone, setWritingTone] = useState<string | null>(null);
   const [writingStyle, setWritingStyle] = useState<string | null>(null);
   const [writingFormat, setWritingFormat] = useState<string | null>(null);
 
   const getSystemMessage = () => {
+    if (userPrompt) return userPrompt.content;
     const message: string[] = [];
     if (writingCharacter) message.push(`You are ${writingCharacter}.`);
     if (writingTone) message.push(`Respond in ${writingTone} tone.`);
@@ -219,7 +225,7 @@ export function ChatRoute() {
         })}
       >
         <Container>
-          {messages?.length === 0 && (
+          {!userPrompt && messages?.length === 0 && (
             <SimpleGrid
               mb="sm"
               spacing="xs"


### PR DESCRIPTION
For your consideration...

Adds a nullable `promptId` property to the chat database entity to keep track of which prompt a chat was launched from, and changes the behavior of the prompt play button so that it will send the user's prompt with the `system` role at the beginning of a new prompt-based chat (instead of the current behavior where the user's prompt is immediately sent as a `user` role message when a prompt play button is clicked).

closes #19 