### PR TITLE
fix scrolling on iOS and desktop

### DIFF
--- a/src/components/ScrollIntoView.tsx
+++ b/src/components/ScrollIntoView.tsx
@@ -1,13 +1,15 @@
-import { ReactNode } from "react";
+import { ReactNode, useRef, useEffect } from "react";
 
 export function ScrollIntoView({ children }: { children: ReactNode }) {
+
+  // Scroll into view as soon as we appear
+  const myRef = useRef(null);
+  useEffect(() => {
+    myRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
   return (
-    <div
-      ref={(node) => {
-        if (!node) return;
-        node.scrollIntoView({ behavior: "smooth" });
-      }}
-    >
+    <div ref={myRef}>
       {children}
     </div>
   );


### PR DESCRIPTION
This updates `<ScrollIntoView>` so that the scroll only occurs on the first render.
This prevents the page from forcing scrolling, which was causing issues https://github.com/deiucanta/chatpad/issues/36
Scrolling only on first render allows the user to scroll as they wish (while the message is still streaming), while still keeping a "nice" UI of scrolling to the latest message.