### PR TITLE
chore: added gpt-4-turbo and gpt-4o as selectable models

### DIFF
--- a/src/routes/ChatRoute.tsx
+++ b/src/routes/ChatRoute.tsx
@@ -275,7 +275,8 @@ export function ChatRoute() {
               })}
               data={[
                 { label: 'GPT-3.5', value: 'gpt-3.5-turbo' },
-                { label: 'GPT-4', value: 'gpt-4' }
+                { label: 'GPT-4', value: 'gpt-4' },
+                { label: 'GPT-4o', value: 'gpt-4o' }
               ]}
               onChange={async (value: 'gpt-3.5-turbo' | 'gpt-4') => {
                 const model = value;

--- a/src/static/config.json
+++ b/src/static/config.json
@@ -53,6 +53,14 @@
       {
         "value": "gpt-4-1106-preview",
         "label": "GPT-4-1106-Preview"
+      },
+      {
+        "value": "gpt-4-turbo",
+        "label": "GPT-4 Turbo"
+      },
+      {
+        "value": "gpt-4o",
+        "label": "GPT-4 omni"
       }
     ],
     "writingCharacters": [


### PR DESCRIPTION
Added the GPT-4 Turbo and GPT-4 omni models to the selectable OpenAI model list.

Resolves #108 #117 